### PR TITLE
Remove date from peoples detail page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,6 +41,8 @@ defaultContentLanguageInSubdir = false
   smartypants = true  # `false` disables all smart punctuation substitutions (e.g. smart quotes, dashes, fractions).
 
 [params]
+  # Show date on people's page
+  show_date = false
   # Color theme.
   #   Choose from `default`, `ocean`, `forest`, `coffee`, `dark`, or `1950s`.
   color_theme = "default"

--- a/content/people/morgan-ernest.md
+++ b/content/people/morgan-ernest.md
@@ -24,8 +24,8 @@ math = false
 
 # Optional featured image (relative to `static/img/` folder).
 [header]
-image = "headers/morganernest.jpg"
-caption = "Morgan Ernest"
+image = ""
+caption = ""
 
 +++
 

--- a/themes/hugo-academic/layouts/partials/article_metadata.html
+++ b/themes/hugo-academic/layouts/partials/article_metadata.html
@@ -2,14 +2,14 @@
 {{ $ := .content }}
 <div class="article-metadata">
 
-  <span class="article-date">
+  <!-- <span class="article-date">
     {{ if ne $.Params.Lastmod $.Params.Date }}
         {{ i18n "last_updated" }}
     {{ end }}
     <time datetime="{{ $.Date }}" itemprop="datePublished dateModified">
       {{ $.Lastmod.Format $.Site.Params.date_format }}
     </time>
-  </span>
+  </span> -->
   <span itemscope itemprop="author publisher" itemtype="http://schema.org/Person">
     <meta itemprop="name" content="{{ $.Site.Params.name }}">
   </span>

--- a/themes/hugo-academic/layouts/partials/article_metadata.html
+++ b/themes/hugo-academic/layouts/partials/article_metadata.html
@@ -1,15 +1,16 @@
 {{ $is_list := .is_list }}
 {{ $ := .content }}
 <div class="article-metadata">
-
-  <!-- <span class="article-date">
+{{ if ne $.Site.Params.show_date false }}
+<span class="article-date">
     {{ if ne $.Params.Lastmod $.Params.Date }}
         {{ i18n "last_updated" }}
     {{ end }}
     <time datetime="{{ $.Date }}" itemprop="datePublished dateModified">
       {{ $.Lastmod.Format $.Site.Params.date_format }}
     </time>
-  </span> -->
+  </span>
+{{ end }}
   <span itemscope itemprop="author publisher" itemtype="http://schema.org/Person">
     <meta itemprop="name" content="{{ $.Site.Params.name }}">
   </span>


### PR DESCRIPTION
We are using date for sorting people but displaying the date in the people detail page doesn't look right. So I have removed it.
Before-----------
![screenshot from 2018-07-05 12-28-27](https://user-images.githubusercontent.com/21103831/42307187-477379d0-804f-11e8-8180-63a3b8aa4628.png)
After--------------
![screenshot from 2018-07-05 12-29-09](https://user-images.githubusercontent.com/21103831/42307231-5cedf01a-804f-11e8-84cc-f92413250dbf.png)
